### PR TITLE
Fixed UMask casing and removed redundant default

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,7 +36,7 @@ define systemd::service (
                           $private_tmp                 = false,
                           $working_directory           = undef,
                           $root_directory              = undef,
-                          $umask                       = '0022',
+                          $umask                       = undef,
                           $nice                        = undef,
                           $oom_score_adjust            = undef,
                         ) {

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -112,7 +112,9 @@ WorkingDirectory=<%= @working_directory %>
 <% if defined?(@root_directory) -%>
 RootDirectory=<%= @root_directory %>
 <% end -%>
-Umask=<%= @umask %>
+<% if defined?(@umask) -%>
+UMask=<%= @umask %>
+<% end -%>
 <% if defined?(@nice) -%>
 Nice=<%= @nice %>
 <% end -%>


### PR DESCRIPTION
The casing for `UMask` is incorrect, it was `Umask` which produces the error: `Unknown lvalue 'Umask' in section 'Service'`.

In addition, since 0022 is already the default, it seems unnecessary to emit the setting at all in the default case.