### PR TITLE
Add timer abstraction.

### DIFF
--- a/manifests/timer.pp
+++ b/manifests/timer.pp
@@ -1,0 +1,54 @@
+define systemd::timer (
+  $onActiveSec = undef,
+  $onBootSec = undef,
+  $onStartupSec = undef,
+  $onUnitActiveSec = undef,
+  $onUnitInactiveSec = undef,
+  $onCalendar = undef,
+  $accuracySec = undef,
+  $randomizedDelaySec = undef,
+  $unit = undef,
+  $persistent = undef,
+  $wakeSystem = undef,
+  $remainAfterElapse = undef,
+  $description = undef,
+  $documentation = undef,
+  $wantedBy = [],
+  $requiredBy = [],
+) {
+  # Timer section
+  if ($persistent) {
+    validate_bool($persistent)
+  }
+  if ($wakeSystem) {
+    validate_bool($wakeSystem)
+  }
+  if ($remainAfterElapse) {
+    validate_bool($remainAfterElapse)
+  }
+
+  # Unit section
+  if ($documentation) {
+    validate_re(
+      $documentation,
+      [ '^https?://', '^file:', '^info:', '^man:'],
+      "Not a supported documentation uri: ${documentation} - It has to be one of 'http://', 'https://', 'file:', 'info:' or 'man:'")
+  }
+
+  # Install section
+  validate_array($wantedBy)
+  validate_array($requiredBy)
+
+  if ($persistent != undef and $persistent == true and $onCalendar == undef) {
+    fail('$persistent being "true" only works with $onCalendar being set.')
+  }
+
+  file { "/etc/systemd/system/${title}.timer":
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("${module_name}/timer.erb"),
+    notify  => Exec['systemctl reload'],
+  }
+}

--- a/spec/acceptance/timer.rb
+++ b/spec/acceptance/timer.rb
@@ -1,0 +1,48 @@
+require 'spec_helper_acceptance'
+require_relative './version.rb'
+
+describe 'systemd timer type' do
+
+  context 'timer setup' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOF
+
+      class { 'systemd': }
+
+      systemd::service { 'test':
+        execstart => '/bin/sleep 60',
+        before    => Service['test'],
+      }
+
+      systemd::timer { 'test':
+        OnBootSec => '1',
+        before    => Service['test'],
+      }
+
+      service { 'test.timer':
+        ensure  => 'running',
+        require => Class['::systemd'],
+      }
+
+      EOF
+
+      # Run it twice and test for idempotency
+      expect(apply_manifest(pp).exit_code).to_not eq(1)
+      expect(apply_manifest(pp).exit_code).to eq(0)
+    end
+
+    describe file("/etc/systemd/system/test.timer") do
+      it { should be_file }
+      its(:content) { should match 'OnBootSec=1' }
+    end
+
+    it "systemctl status" do
+      expect(shell("systemctl status test.timer").exit_code).to be_zero
+    end
+
+    it "check sleep" do
+      expect(shell("ps -fea | grep sleep").exit_code).to be_zero
+    end
+  end
+end

--- a/templates/timer.erb
+++ b/templates/timer.erb
@@ -1,0 +1,26 @@
+[Unit]
+<% if defined?(@description) -%>
+Description=<%= @description %>
+<% end -%>
+<% if defined?(@documentation) -%>
+Documentation = <%= @documentation %>
+<% end -%>
+
+<% if @wantedBy.any? || @requiredBy.any?-%>
+[Install]
+<% if @wantedBy.any? -%>
+WantedBy=<%= @wantedBy.join(' ') %>
+<% end -%>
+<% if @requiredBy.any? -%>
+RequiredBy=<%= @requiredBy.join(' ') %>
+<% end -%>
+<% end -%>
+
+[Timer]
+<%
+    %w(onActiveSec onBootSec onStartupSec onUnitActiveSec onUnitInactiveSec onCalendar accuracySec randomizedDelaySec unit persistent wakeSystem remainAfterElapse).each do | variableName |
+-%>
+    <%- if scope[variableName].to_s != 'undef' -%>
+<%= variableName.sub(/^(.)/) { |match| match.upcase } -%>=<%= scope[variableName] %>
+    <%- end -%>
+<% end -%>


### PR DESCRIPTION
Hey there,

I have added a timer abstraction to go along with the service abstraction you already have in there.

It is pretty basic for now, but should be expandable easily.
I am not sure, if the test I copied and rephrased is actually good. I do not have experience with Puppet module testing.

Every configuration in the timer.pp is strictly based on the systemd docs and has the sensible defaults, if any, suggested there. I have not supplied defaults for settings that are not especially needed to configure a timer.

If you have any suggestions, please feel free to tell me.

I have also made some changes that bother me with your current implementation of the 'service.pp' along the way. I will put these in a seperate PR, so they do not distract this one.