### PR TITLE
Make some service abstraction improvements.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,7 @@ define systemd::service (
                           $execreload                  = undef,
                           $execstartpre                = undef,
                           $execstartpost               = undef,
-                          $restart                     = 'always',
+                          $restart                     = 'no',
                           $user                        = 'root',
                           $group                       = 'root',
                           $servicename                 = $name,
@@ -17,7 +17,7 @@ define systemd::service (
                           $env_vars                    = [],
                           $environment_files           = [],
                           $wants                       = [],
-                          $wantedby                    = [ 'multi-user.target' ],
+                          $wantedby                    = [],
                           $requiredby                  = [],
                           $after_units                 = [],
                           $before_units                = [],
@@ -42,8 +42,8 @@ define systemd::service (
                           $oom_score_adjust            = undef,
                           $startlimitinterval          = undef,
                           $startlimitburst             = undef,
-                          $standard_output             = 'syslog',
-                          $standard_error              = 'syslog',
+                          $standard_output             = undef,
+                          $standard_error              = undef,
                           $killmode                    = undef,
                         ) {
 
@@ -61,10 +61,26 @@ define systemd::service (
   {
     fail('Incompatible options: There are multiple execstart values and Type is not "oneshot"')
   }
+  elsif ($type == 'oneshot' and  is_array($execstart))
+  {
+    $execstart_entries = $execstart
+  }
+  else
+  {
+    $execstart_entries = any2array($execstart)
+  }
 
   if($type != 'oneshot' and is_array($execstop) and count($execstop) > 1)
   {
     fail('Incompatible options: There are multiple execstart values and Type is not "oneshot"')
+  }
+  elsif($type == "oneshot" and  is_array($execstop))
+  {
+    $execstop_entries = $execstop
+  }
+  else
+  {
+    $execstop_entries = any2array($execstop)
   }
 
   # Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -22,24 +22,12 @@ Requires=<%= @requires.join(' ') %>
 <% end -%>
 
 [Service]
-<% if defined?(@execstart) -%>
-  <%- if @execstart.kind_of?(Array) -%>
-    <%- @execstart.each do |val| -%>
-ExecStart=<%= val %>
-    <%- end -%>
-  <%- else -%>
-ExecStart=<%= @execstart %>
+<%- @execstart_entries.each do |execstart_entry| -%>
+ExecStart=<%= execstart_entry %>
   <%- end -%>
-<% end -%>
-<% if defined?(@execstop) -%>
-  <%- if @execstop.kind_of?(Array) -%>
-    <%- @execstop.each do |val| -%>
-ExecStop=<%= val %>
-    <%- end -%>
-  <%- else -%>
-ExecStop=<%= @execstop %>
+<%- @execstop_entries.each do |execstart_entry| -%>
+ExecStart=<%= execstart_entry %>
   <%- end -%>
-<% end -%>
 <% if defined?(@execreload) -%>
 ExecReload=<%= @execreload %>
 <% end -%>
@@ -62,8 +50,12 @@ ExecStartPost=<%= @execstartpost %>
   <%- end -%>
 <% end -%>
 Restart=<%= @restart %>
+<% if defined?(@standard_output) -%>
 StandardOutput=<%= @standard_output %>
+<% end -%>
+<% if defined?(@standard_error) -%>
 StandardError=<%= @standard_error %>
+<% end -%>
 SyslogIdentifier=<%= @servicename %>
 User=<%= @user %>
 Group=<%= @group %>
@@ -108,6 +100,9 @@ RestartPreventExitStatus=<%= @restart_prevent_exit_status %>
 <% end -%>
 <% if defined?(@limit_nofile) -%>
 LimitNOFILE = <%= @limit_nofile %>
+<% end -%>
+<% if defined?(@umask) -%>
+UMask = <%= @umask %>
 <% end -%>
 <% if defined?(@limit_nproc) -%>
 LimitNPROC = <%= @limit_nproc %>
@@ -154,8 +149,12 @@ StartLimitBurst=<%= @startlimitburst %>
 KillMode=<%= @killmode %>
 <% end -%>
 
+<% if @wantedby.any? || @requiredby.any?-%>
 [Install]
+<% if @wantedby.any? -%>
 WantedBy=<%= @wantedby.join(' ') %>
+<% end -%>
 <% if @requiredby.any? -%>
 RequiredBy=<%= @requiredby.join(' ') %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
I found these things while creating the abstract timers, I have opened up another PR for.
As I said there, I was browsing through the documentation of systemd. I stumbled across some of the configuration keys and their sensible defaults chosen by the package maintainer.

As you see, I have changed the default values of 'restart', 'wantedBy' and the outputs.
The restart thing could come in handy for standalone services, but would not be that useful for timer based services. Sometimes, services are just there to 'run once in a while', because they have a much better API than a file lying in an application folder with no configuration surrounding it and ppl asking: What should I do with this.

The second thing: 'wantedBy'.
There seems to be not such thing as a 'default' here. So I do not get, why you would want to force it onto services. I have removed it, because of that.

The output is pretty much unecessary. Forcing it to syslog might break with the modules default of going into journalctl which is the much better choice with systemd. So, gone it is.

I know, the first two MIGHT introduce breaking changes, but hey, that's what major versions are for ;)

The second thing I have done, was getting rid of logic in a template file. Logic does not belong in a template file. There should be as few `if`s or in general logical constructions as possible. The 'array check' of `execstart` and `execstop` belongs in the `service.pp`.

Yeah..that's all :)

I hope you appreciate the help.
Let me hear, what you think.