### PR TITLE
systemd::timer camelcase + nil values

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  forge_modules:
+    stdlib: puppetlabs/stdlib
+  symlinks:
+    systemd: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ junit
 log
 spec/fixtures/
 Gemfile.lock
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
+gem 'rspec', '< 3.2',      :require => false if RUBY_VERSION =~ /^1\.8/
+gem 'rspec-puppet-facts',        :require => false
+gem 'metadata-json-lint',  :require => false
 
 group :system_tests do
   gem 'beaker',              :require => false
@@ -12,7 +15,4 @@ group :system_tests do
   gem 'beaker_spec_helper',  :require => false
   gem 'beaker-puppet_install_helper', :require => false
   gem 'serverspec',          :require => false
-  gem 'rspec', '< 3.2',      :require => false if RUBY_VERSION =~ /^1\.8/
-  gem 'rspec-puppet',        :require => false
-  gem 'metadata-json-lint',  :require => false
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 describe 'systemd' do
-
-  context 'with defaults for all parameters' do
-    it { should contain_class('systemd') }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      context 'with defaults for all parameters' do
+        it { should contain_class('systemd') }
+      end
+    end
   end
 end

--- a/spec/defines/timer_spec.rb
+++ b/spec/defines/timer_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'systemd::timer' do
+  let(:pre_condition) do
+    "include '::systemd'"
+  end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let (:facts) {facts}
+      let(:title) { 'foobar' }
+      context 'with minimum parameters' do
+        it { should compile.with_all_deps }
+        it do
+          should contain_file('/etc/systemd/system/foobar.timer')
+            .without_content(/^OnCalendar=/)
+        end
+      end
+      context 'with calendar parameters' do
+        let(:params) do
+          {
+            on_calendar: '06:00:00'
+          }
+        end
+        it { should compile.with_all_deps }
+        it do
+          should contain_file('/etc/systemd/system/foobar.timer')
+            .with_content(/^OnCalendar=06:00:00$/)
+        end
+      end
+      context 'with on_boot_sec parameters' do
+        let(:params) do
+          {
+            on_boot_sec: '1h'
+          }
+        end
+        it { should compile.with_all_deps }
+        it do
+          should contain_file('/etc/systemd/system/foobar.timer')
+            .with_content(/^OnBootSec=1h$/)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts

--- a/templates/timer.erb
+++ b/templates/timer.erb
@@ -20,7 +20,7 @@ RequiredBy=<%= @requiredby.join(' ') %>
 <%
     %w(on_active_sec on_boot_sec on_startup_sec on_unit_active_sec on_unit_inactive_sec on_calendar accuracy_sec randomized_delay_sec unit persistent wake_system remain_after_elapse).each do | variableName |
 -%>
-    <%- if scope[variableName].to_s != 'undef' -%>
-<%= variableName.sub(/^(.)/) { |match| match.upcase } -%>=<%= scope[variableName] %>
+    <%- if scope[variableName].to_s != 'undef' and !scope[variableName].nil? -%>
+<%= variableName.gsub(/(^(.)|_(.))/){|match| match.upcase }.gsub('_', '') -%>=<%= scope[variableName] %>
     <%- end -%>
 <% end -%>


### PR DESCRIPTION
This is related to @func0der's suggestion about changing the `timer.erb` template, in #44:
> The loop in the template, which only converts the first letter to upper case, needs to be changed to convert underscore_writing to UpperCamelCase.

- When passing `on_calendar => '06:00:00'` ERB template would produce
  `On_calendar=`.. instead of `OnCalendar=`.
- Moreover, all undef values were unset because of the var.to_s != 'undef' which
  does not work with Puppet4. The file was full of unassigned directives like
 `/^OnBootSec=$/`
- Added spec tests using rspec-puppet-facts to loop over supported OS and spec
  tests for systemd::timer defined type