### PR TITLE
Add ability to use OnFailure - Used for notifications on errors

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,7 @@ define systemd::service (
                           $before_units                = [],
                           $requires                    = [],
                           $conflicts                   = [],
+                          $on_failure                  = [],
                           $permissions_start_only      = false,
                           $timeoutstartsec             = undef,
                           $timeoutstopsec              = undef,
@@ -77,6 +78,7 @@ define systemd::service (
   validate_array($before_units)
   validate_array($requires)
   validate_array($conflicts)
+  validate_array($on_failure)
 
   if versioncmp($::puppetversion, '4.0.0') >= 0
   {

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "management of systemd services (/etc/systemd/system/...), basic socket management",
   "license": "Apache-2.0",
   "source": "https://github.com/NTTCom-MS/eyp-systemd",
-  "project_page": null,
+  "project_page": "https://github.com/NTTCom-MS/eyp-systemd",
   "issues_url": "https://github.com/NTTCom-MS/eyp-systemd/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 < 9.9.9"},

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -1,6 +1,6 @@
 [Unit]
 <% if defined?(@description) -%>
-Description = <%= @description %>
+Description=<%= @description %>
 <% end -%>
 <% if defined?(@after) -%>
 After=<%= @after %>
@@ -19,6 +19,9 @@ Conflicts=<%= @conflicts.join(' ') %>
 <% end -%>
 <% if @requires.any? -%>
 Requires=<%= @requires.join(' ') %>
+<% end -%>
+<% if @on_failure.any? -%>
+OnFailure=<%= @on_failure.join(' ') %>
 <% end -%>
 
 [Service]


### PR DESCRIPTION
Hi,

this small improvement provides the ability to call other systemd-unit(s) if there is an failure in the main unit.
We needed that to implement email notifications if a timer failes. You can read more on that topic here:
http://northernlightlabs.se/systemd.status.mail.on.unit.failure
The blog does not belong to me.