### PR TITLE
Fix execstop not needed for type oneshot timers

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
 define systemd::service (
                           $execstart,
-                          $execstop                    = undef,
+                          $execstop                    = [],
                           $execreload                  = undef,
                           $execstartpre                = undef,
                           $execstartpost               = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "management of systemd services (/etc/systemd/system/...), basic socket management",
   "license": "Apache-2.0",
   "source": "https://github.com/NTTCom-MS/eyp-systemd",
-  "project_page": null,
+  "project_page": "https://github.com/NTTCom-MS/eyp-systemd",
   "issues_url": "https://github.com/NTTCom-MS/eyp-systemd/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0 < 9.9.9"},


### PR DESCRIPTION
Hi,

this PR fixes an issue if you use type oneshot and timer to activate the unit. There is no execstop needed if the process exits itself. But the module will create an incorrect line if you do not supply any execstop. (ExecStop=)