### PR TITLE
manage journald.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,10 @@
 #
 # https://wiki.archlinux.org/index.php/systemd#Service_types
 #
-class systemd($removeipc = 'no') inherits systemd::params {
+class systemd(
+  $manage_journald = false,
+  $removeipc = 'no',
+) inherits systemd::params {
 
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',
@@ -20,4 +23,8 @@ class systemd($removeipc = 'no') inherits systemd::params {
   }
 
   include ::systemd::logind
+
+  if ($manage_journald) {
+    include ::systemd::journald
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 #
 class systemd(
   $manage_journald = false,
+  $manage_logind = true,
   $removeipc = 'no',
 ) inherits systemd::params {
 
@@ -22,7 +23,9 @@ class systemd(
     refreshonly => true,
   }
 
-  include ::systemd::logind
+  if ($manage_logind) {
+    include ::systemd::logind
+  }
 
   if ($manage_journald) {
     include ::systemd::journald

--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -1,0 +1,63 @@
+class systemd::journald(
+  $compress = true,
+  $forward_to_console = false,
+  $forward_to_kmsg = false,
+  $forward_to_syslog = true,
+  $forward_to_wall = true,
+  $max_file_sec = '1month',
+  $max_level_console = 'info',
+  $max_level_kmsg = 'notice',
+  $max_level_store = 'debug',
+  $max_level_syslog = 'debug',
+  $max_level_wall = 'emerg',
+  $max_retention_sec = undef,
+  $rate_limit_burst = 1000,
+  $rate_limit_interval = '30s',
+  $runtime_keep_free = undef,
+  $runtime_max_files_ize = undef,
+  $runtime_max_use = undef,
+  $seal = true,
+  $split_mode = 'uid',
+  $storage = 'auto',
+  $sync_interval_sec = '5m',
+  $system_keep_free = undef,
+  $system_max_file_size = undef,
+  $system_max_use = undef,
+  $tty_path = '/dev/console'
+) inherits systemd {
+
+  validate_bool($compress, $forward_to_console, $forward_to_kmsg,
+                $forward_to_syslog, $forward_to_wall, $seal)
+
+  validate_integer($rate_limit_burst)
+
+  validate_re($max_level_console, ['^emerg$', '^alert$', '^crit$', '^err$',
+    '^warning$', '^notice$', '^info$', '^debug$'])
+
+  validate_re($max_level_kmsg, ['^emerg$', '^alert$', '^crit$', '^err$',
+    '^warning$', '^notice$', '^info$', '^debug$'])
+
+  validate_re($max_level_store, ['^emerg$', '^alert$', '^crit$', '^err$',
+    '^warning$', '^notice$', '^info$', '^debug$'])
+
+  validate_re($max_level_syslog, ['^emerg$', '^alert$', '^crit$', '^err$',
+    '^warning$', '^notice$', '^info$', '^debug$'])
+
+  validate_re($max_level_wall, ['^emerg$', '^alert$', '^crit$', '^err$',
+    '^warning$', '^notice$', '^info$', '^debug$'])
+
+  file { '/etc/systemd/journald.conf':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template("${module_name}/journald.erb"),
+    notify  => Exec['restart-systemd-journald'],
+  }
+
+  exec { 'restart-systemd-journald':
+    command     => 'systemctl restart systemd-journald.service',
+    refreshonly => true,
+  }
+
+}

--- a/templates/journald.erb
+++ b/templates/journald.erb
@@ -1,0 +1,69 @@
+###  puppet managed file
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# See journald.conf(5) for details
+<%-
+
+var_to_systemd_directives = {
+  'compress' => 'Compress',
+  'forward_to_console' => 'ForwardToConsole',
+  'forward_to_kmsg' => 'ForwardToKMsg',
+  'forward_to_syslog' => 'ForwardToSyslog',
+  'forward_to_wall' => 'ForwardToWall',
+  'max_file_sec' => 'MaxFileSec',
+  'max_level_console' => 'MaxLevelConsole',
+  'max_level_kmsg' => 'MaxLevelKMsg',
+  'max_level_store' => 'MaxLevelStore',
+  'max_level_syslog' => 'MaxLevelSyslog',
+  'max_level_wall' => 'MaxLevelWall',
+  'max_retention_sec' => 'MaxRetentionSec',
+  'rate_limit_burst' => 'RateLimitBurst',
+  'rate_limit_interval' => 'RateLimitInterval',
+  'run_time_keep_free' => 'RuntimeKeepFree',
+  'run_time_max_file_size' => 'RuntimeMaxFileSize',
+  'run_time_max_use' => 'RuntimeMaxUse',
+  'seal' => 'Seal',
+  'split_mode' => 'SplitMode',
+  'storage' => 'Storage',
+  'sync_interval_sec' => 'SyncIntervalSec',
+  'system_keep_free' => 'SystemKeepFree',
+  'system_max_file_size' => 'SystemMaxFileSize',
+  'system_max_use' => 'SystemMaxUse',
+  'tty_path' => 'TTYPath',
+}
+
+-%>
+
+[Journal]
+<%
+  all_var_names = %w(compress forward_to_console forward_to_kmsg
+    forward_to_syslog forward_to_wall max_file_sec max_level_console
+    max_level_kmsg max_level_store max_level_syslog max_level_wall
+    max_retention_sec rate_limit_burst rate_limit_interval
+    run_time_keep_free run_time_max_file_size run_time_max_use seal
+    split_mode storage sync_interval_sec system_keep_free
+    system_max_file_size system_max_use tty_path)
+
+  bool_var_names = %w(compress forward_to_console forward_to_kmsg
+    forward_to_syslog forward_to_wall seal)
+
+all_var_names.each do | variableName | -%>
+<%- if scope[variableName].to_s != 'undef' and !scope[variableName].nil?
+  if bool_var_names.include? variableName
+    myvalue = scope.function_bool2yesno([scope[variableName]])
+  elsif  scope[variableName].is_a?(Array)
+    next if scope[variableName].empty?
+    myvalue = scope[variableName].join(' ')
+  else
+    myvalue = scope[variableName]
+  end
+-%>
+<%= var_to_systemd_directives[variableName] -%>=<%= myvalue %>
+<%- end -%>
+<% end -%>


### PR DESCRIPTION
This PR adds support to manage `journald.conf` as well.
This feature is disabled by default and can be enabled by setting `$systemd::manage_journald` to `true`.

While here, I've added `$systemd::manage_logind` to make it possible to control journald and logind independently.