### PR TITLE
Fix #104 dependency circle with puppet 4

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -81,14 +81,7 @@ define systemd::service (
     validate_re($restart, [ '^no$', '^on-success$', '^on-failure$', '^on-abnormal$', '^on-watchdog$', '^on-abort$', '^always$'], "Not a supported restart type: ${restart} - Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always")
   }
 
-  if versioncmp($::puppetversion, '4.0.0') >= 0
-  {
-    contain ::systemd
-  }
-  else
-  {
-    include ::systemd
-  }
+  include ::systemd
 
   file { "/etc/systemd/system/${servicename}.service":
     ensure  => 'present',


### PR DESCRIPTION
As mentioned in #104 we are getting an dependency circle with this changeset. (we are creating a service and timer for that one)

Provisioning is running fine for is as long as there is no contain-statement.