### PR TITLE
Add array support for ExecReload

### DIFF
--- a/templates/service.erb
+++ b/templates/service.erb
@@ -47,7 +47,13 @@ ExecStop=<%= @execstop %>
   <%- end -%>
 <% end -%>
 <% if defined?(@execreload) -%>
+  <%- if @execreload.kind_of?(Array) -%>
+    <%- @execreload.each do |val| -%>
+ExecReload=<%= @val %>
+    <%- end -%>
+  <%- else -%>
 ExecReload=<%= @execreload %>
+  <%- end -%>
 <% end -%>
 <% if defined?(@execstartpre) -%>
   <%- if @execstartpre.kind_of?(Array) -%>


### PR DESCRIPTION
As specified in systemd service [man page](https://www.freedesktop.org/software/systemd/man/systemd.service.html) `ExecReload` can be used multiple times like `ExecStart`.