### PR TITLE
define default variables to avoid NilClass

### DIFF
--- a/manifests/target.pp
+++ b/manifests/target.pp
@@ -2,6 +2,16 @@ define systemd::target(
                         $target_name   = $name,
                         $description   = undef,
                         $allow_isolate = false,
+                        $after         = undef,
+                        $wants         = [],
+                        $after_units   = [],
+                        $before_units  = [],
+                        $conflicts     = [],
+                        $requires      = [],
+                        $on_failure    = [],
+                        $partof        = undef,
+                        $documentation = undef,
+                        
                       ) {
   include ::systemd
 


### PR DESCRIPTION
Hi,

this update fixes NilClass issue while defining a target. solves issue #128 