### PR TITLE
include the service name to make declaration unique

### DIFF
--- a/manifests/service/dropin.pp
+++ b/manifests/service/dropin.pp
@@ -93,19 +93,19 @@ define systemd::service::dropin (
     notify => Exec['systemctl daemon-reload'],
   }
 
-  concat::fragment { "service dropin ${dropin_name} unit":
+  concat::fragment { "service dropin ${servicename} ${dropin_name} unit":
     target  => "/etc/systemd/system/${servicename}.service.d/${dropin_order}-${dropin_name}.conf",
     order   => '00',
     content => template("${module_name}/section/unit.erb"),
   }
 
-  concat::fragment { "service dropin ${dropin_name} install":
+  concat::fragment { "service dropin ${servicename} ${dropin_name} install":
     target  => "/etc/systemd/system/${servicename}.service.d/${dropin_order}-${dropin_name}.conf",
     order   => '01',
     content => template("${module_name}/section/install.erb"),
   }
 
-  concat::fragment { "service dropin ${dropin_name} service":
+  concat::fragment { "service dropin ${servicename} ${dropin_name} service":
     target  => "/etc/systemd/system/${servicename}.service.d/${dropin_order}-${dropin_name}.conf",
     order   => '02',
     content => template("${module_name}/section/service.erb"),


### PR DESCRIPTION
Hi,

there was a duplicate declaration when multiple dropin are declared.  

`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Concat::Fragment[service dropin override unit] is already declared at.. `

I have added the service name in the concat definition to make sure each dropin are uniq. (tested and working )

Kind regards