### PR TITLE
feat: add support for suse 11.4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,6 +65,9 @@ class systemd::params {
     {
       case $::operatingsystemrelease
       {
+        /11.4/:
+        {
+        }
         /^1[23].*/:
         {
         }

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
     },
     {
       "operatingsystem": "SLES",
-      "operatingsystemrelease": [ "12", "12.1", "12.2", "12.3" ]
+      "operatingsystemrelease": [ "11.4", "12", "12.1", "12.2", "12.3" ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
We were using this module for sles 11.4 systems for a while now. After updating to the latest version support for 11.4 was suddenly dropped.

We assume this was not intentional, as the module is working properly on 11.4. We successfully tested this with the changes below.

Please consider readding support for 11.4.