### PR TITLE
Fix to be able to unset wantedby default value

### DIFF
--- a/templates/section/install.erb
+++ b/templates/section/install.erb
@@ -1,5 +1,5 @@
 [Install]
-<% if defined?(@wantedby) -%>
+<% if @wantedby.any? -%>
 WantedBy=<%= @wantedby.join(' ') %>
 <% end -%>
 <% if @requiredby.any? -%>


### PR DESCRIPTION
Change is required to override the module default value of `[ 'multi-user.target' ]` if you don't want to have any wantedby (e.g. .timer)