### PR TITLE
Allow multiple onCalendar elements

### DIFF
--- a/spec/defines/timer_spec.rb
+++ b/spec/defines/timer_spec.rb
@@ -27,6 +27,22 @@ describe 'systemd::timer' do
             .with_content(/^OnCalendar=06:00:00$/)
         end
       end
+      context 'with multiple calendar parameters' do
+        let(:params) do
+          {
+            on_calendar: [
+              '06:00:00',
+              '08:00:00',
+            ]
+          }
+        end
+        it { should compile.with_all_deps }
+        it do
+          should contain_file('/etc/systemd/system/foobar.timer')
+            .with_content(/^OnCalendar=06:00:00$/)
+            .with_content(/^OnCalendar=08:00:00$/)
+        end
+      end
       context 'with on_boot_sec parameters' do
         let(:params) do
           {

--- a/templates/section/timer.erb
+++ b/templates/section/timer.erb
@@ -3,6 +3,8 @@
     %w(on_active_sec on_boot_sec on_startup_sec on_unit_active_sec on_unit_inactive_sec on_calendar accuracy_sec randomized_delay_sec unit persistent wake_system remain_after_elapse).each do | variableName |
 -%>
     <%- if scope[variableName].to_s != 'undef' and !scope[variableName].nil? -%>
-<%= variableName.gsub(/(^(.)|_(.))/){|match| match.upcase }.gsub('_', '') -%>=<%= scope[variableName] %>
+      <%- Array(scope[variableName]).each do | value | -%>
+<%= variableName.gsub(/(^(.)|_(.))/){|match| match.upcase }.gsub('_', '') -%>=<%= value %>
+      <%- end -%>
     <%- end -%>
 <% end -%>


### PR DESCRIPTION
On systemd timer it is allowed to have multiple OnCalendar elements like described here:
https://wiki.archlinux.org/index.php/Systemd/Timers#Realtime_timer

This PR allows to pass an array which results in multiple elements in the config file then.