### PR TITLE
Added support for Amazon Linux 2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,16 @@ class systemd::params {
             default: { fail('Unsupported RHEL/CentOS version!')  }
           }
         }
+        'Amazon':
+        {
+          case $::operatingsystemrelease
+          {
+            /^[2].*$/:
+            {
+            }
+            default: { fail('Unsupported RHEL/CentOS version!')  }
+          }
+        }
         default:
         {
           case $::operatingsystemrelease


### PR DESCRIPTION
Given that Amazon Linux 2 has full support for systemd, I've added it as a supported `RedHat` derivative. I've tested this at my end and it's working perfectly. 👍 