### PR TITLE
switch from contain to include

### DIFF
--- a/manifests/automount.pp
+++ b/manifests/automount.pp
@@ -29,7 +29,7 @@ define systemd::automount (
                             # global
                             $ensure                          = 'present',
                           ) {
-  contain ::systemd
+  include ::systemd
 
   $mount_name = regsubst(regsubst($where, '/', '-', 'G'), '^-', '', '')
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -42,7 +42,7 @@ define systemd::mount(
                         $ensure                          = 'present',
                       ) {
 
-  contain ::systemd
+  include ::systemd
 
   $mount_name = regsubst(regsubst($where, '/', '-', 'G'), '^-', '', '')
 

--- a/manifests/service/dropin.pp
+++ b/manifests/service/dropin.pp
@@ -96,7 +96,7 @@ define systemd::service::dropin (
   #   }
   # }
 
-  contain ::systemd
+  include ::systemd
 
   $servicename_filtered = regsubst(regsubst(regsubst($servicename, '/', '-', 'G'), '^-', '', ''), '@', '_at_', 'G')
 

--- a/manifests/sysvwrapper.pp
+++ b/manifests/sysvwrapper.pp
@@ -6,7 +6,7 @@ define systemd::sysvwrapper (
                               $wait_time_on_startup = '1s',
                               $restart              = 'no',
                             ) {
-  contain ::systemd
+  include ::systemd
 
   file { "${initscript}.sysvwrapper.status":
     ensure  => $ensure,


### PR DESCRIPTION
using contain can lead to cyclic dependency errors as contain enforces
the class declaration to take place where the contain is mentioned.

using include offers more flexibility for puppet to decide when the
class really should be declared.

fixes a problem at a customer who uses this module